### PR TITLE
Use safe_load instead of load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 python:
   - 2.7
-  - 3.4
+  - 3.6
+  - 3.7
+  - 3.8
+  - 3.9
 install:
   - pip install -e .[test]
 script:

--- a/settings_overrider.py
+++ b/settings_overrider.py
@@ -1,6 +1,6 @@
 import os
 
-from yaml import load as load_yaml
+from yaml import safe_load as load_yaml
 
 
 def override(settings, yaml=None, env=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 testpaths = tests
 addopts =
     --cov settings_overrider


### PR DESCRIPTION
Silences the warning in issue: https://github.com/kottenator/settings-overrider/issues/2

However, also changes default behavior: https://stackoverflow.com/a/63916315

Is there any reasonable situation where this dict content patcher would need to have some sort of Python injected via YAML?  It does not seem that way to me but I'm not familiar with Django or this plugin